### PR TITLE
Development

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,9 +52,11 @@ Style/RescueStandardError:
     # an error getting evidence, we treat it as no evidence.
     - 'app/lib/evidence.rb'
 Metrics/AbcSize:
-  Max: 20
+  Max: 30
   Exclude:
     - 'db/migrate/*'
+Metrics/ModuleLength:
+  Max: 250
 Metrics/ClassLength:
   Exclude:
     - 'db/migrate/*'
@@ -64,11 +66,21 @@ Layout/LineLength:
   # Exclude:
   #   - 'db/migrate/*'
 Metrics/MethodLength:
- Exclude:
-   - 'db/migrate/*'
+  Max: 30
+  Exclude:
+    - 'db/migrate/*'
+Metrics/BlockLength:
+  Max: 30
+  Exclude:
+    - 'db/migrate/*'
+    - 'db/schema.rb'
+    - 'spec/**/*.rb'
 Rails/SkipsModelValidations:
   Exclude:
-    - 'test/**/*.rb'
+    - 'spec/**/*.rb'
+Style/MethodCalledOnDoEndBlock:
+  Exclude:
+    - 'spec/**/*.rb'
 Style/Copyright:
   Enabled: false
 Style/InlineComment:

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,5 @@ group :test do
   gem 'rspec-sorbet'
 end
 
-
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -33,7 +33,9 @@ class TasksController < ApplicationController
       @task.errors.add(:name, e.to_s)
     end
 
-    if @task.save
+    # we don't want to re-run save here because it will remove the
+    # context validation from the handler and check "valid?"
+    if @task.errors.empty?
       render json: @task, status: :created, adapter: :json
     else
       render status: :unprocessable_entity, json: { error: @task.errors }

--- a/spec/requests/tasks_spec.rb
+++ b/spec/requests/tasks_spec.rb
@@ -104,6 +104,14 @@ RSpec.describe '/tasks', type: :request do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.content_type).to match(a_string_including('application/json'))
       end
+
+      it 'renders context errors' do
+        task_attributes = valid_attributes.merge({ context: { bad_param: true, dummy: 99 } })
+        post tasks_url, params: { task: task_attributes }, headers: valid_headers, as: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+        json_response = JSON.parse(response.body).deep_symbolize_keys
+        expect(json_response[:error][:context]).not_to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
Context validation errors now correctly sent across the API